### PR TITLE
Change Decidim Version and fix behavior inside content_block for blueprint creation

### DIFF
--- a/app/assets/javascripts/decidim/navigation_maps/admin/navigation_maps.js
+++ b/app/assets/javascripts/decidim/navigation_maps/admin/navigation_maps.js
@@ -65,6 +65,14 @@ MapEditor.prototype.createMap = function() {
       self.blueprint[area] = e.target.toGeoJSON();
       $('#leaflet-tr-' + area).replaceWith(self.getTr(area, self.blueprint[area]));
     });
+    e.layer.on('mouseover', function(e) {
+      e.target.setStyle(self.highlightStyle);
+      $('#leaflet-tr-' + e.target._leaflet_id).addClass('selected');
+    });
+    e.layer.on('mouseout', function(e) {
+      e.target.setStyle(self.defaultStyle);
+      $('#leaflet-tr-' + e.target._leaflet_id).removeClass('selected');
+    });
   });
 
   self.map.on('pm:remove', function(e) {

--- a/lib/decidim/navigation_maps/version.rb
+++ b/lib/decidim/navigation_maps/version.rb
@@ -4,6 +4,6 @@ module Decidim
   # This holds the decidim-meetings version.
   module NavigationMaps
     VERSION = "0.19.0alpha"
-    DECIDIM_VERSION = "0.19.0"
+    DECIDIM_VERSION = ">= 0.18.0"
   end
 end


### PR DESCRIPTION
This PR has a change in the decidim version: from 0.19.0 to >= 0.18.0 and some fixes in the javascript that handled the creation of areas and their visualization.